### PR TITLE
updating namespace test to work with Steal 0.16 or Steal 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 addons:
-  firefox: "latest"
+  firefox: "51.0"

--- a/can-cid_test.js
+++ b/can-cid_test.js
@@ -48,7 +48,8 @@ QUnit.test('should throw if can-namespace.cid is already defined', function() {
 		start();
 	})
 	.catch(function(err) {
-		ok(err && err.message.indexOf('can-cid') >= 0, 'should throw an error about can-cid');
+		var errMsg = err && err.message || err;
+		ok(errMsg.indexOf('can-cid') >= 0, 'should throw an error about can-cid');
 		start();
 	});
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-cid/issues/11.