### PR TITLE
Add @package to the docs

### DIFF
--- a/can-cid.js
+++ b/can-cid.js
@@ -2,6 +2,7 @@ var namespace = require('can-namespace');
 /**
  * @module {function} can-cid
  * @parent can-infrastructure
+ * @package ./package.json
  * @signature `cid(object, optionalObjectType)`
  *
  * Get a unique identifier for the object, optionally prefixed by a type name.


### PR DESCRIPTION
This fixes an issue with the GitHub star and npm download buttons not appearing in the rendered canjs.com docs.