### PR TITLE
Add dom-cid and move get-cid

### DIFF
--- a/dom-cid.js
+++ b/dom-cid.js
@@ -1,0 +1,12 @@
+var expando = "can" + new Date();
+var uuid = 0;
+
+module.exports = {
+	expando: expando,
+	getCid: function () {
+		return this[expando];
+	},
+	cid: function () {
+		return this[expando] || (this[expando] = ++uuid);
+	}
+};

--- a/get-cid.js
+++ b/get-cid.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var CID = require("can-cid");
+var domCid = require("./dom-cid");
+
+module.exports = function(obj){
+	if(typeof obj.nodeType === "number") {
+		return domCid.cid.call(obj);
+	} else {
+		var type = typeof obj;
+		var isObject = type !== null && (type === "object" || type === "function");
+		return type+":"+( isObject ? CID(obj) : obj );
+	}
+};


### PR DESCRIPTION
In an effort to remove a circular dependency from `can-util`, `can-util/js/cid/get-cid` is being moved here as well as the CID logic inside `can-util/dom/data/core`.